### PR TITLE
Patch 0.1.1

### DIFF
--- a/Maximus.json
+++ b/Maximus.json
@@ -9,6 +9,6 @@
 	"priority": 0,
 	"badge_colour": "f51bbc",
 	"badge_text_colour": "f8a100",
-	"version": "0.1.0-beta",
+	"version": "0.1.1-beta",
 	"dependencies": []
 }

--- a/lovely.toml
+++ b/lovely.toml
@@ -44,7 +44,7 @@ if self.ability.name == 'Egg' then
 '''
 position = "after"
 payload = '''
-if next(SMODS.find_card('j_mxms_microwave')) and pseudorandom('eggsplode', 1, 20) == 1 then
+if next(SMODS.find_card('j_mxms_microwave')) and pseudorandom('eggsplode' .. G.GAME.round_resets.ante, 1, 20) == 1 then
     G.E_MANAGER:add_event(Event({
         func = function()
             play_sound('mxms_eggsplosion')
@@ -1680,7 +1680,7 @@ position = "at"
 payload = '''
 if polled_rate > check_rate and polled_rate <= check_rate + v.val then
     local card = create_card(v.type, area, nil, nil, nil, nil, nil, 'sho')
-    if card.ability.set == 'Joker' and next(SMODS.find_card('j_mxms_coupon')) and pseudorandom('cou', 1 * G.GAME.probabilities.normal, 30) == 30 then
+    if card.ability.set == 'Joker' and next(SMODS.find_card('j_mxms_coupon')) and pseudorandom('cou' .. G.GAME.round_resets.ante, 1 * G.GAME.probabilities.normal, 10) == 10 then
         card.cost = 0
     end
 '''

--- a/lovely.toml
+++ b/lovely.toml
@@ -1332,7 +1332,8 @@ if self.ability.set == 'Joker' then
         G.E_MANAGER:add_event(Event({func = function()
             for k, v in pairs(G.jokers.cards) do
                 if v.config.center.key == 'j_mxms_clown_car' then
-                    v.ability.extra.mult = v.ability.extra.mult + 2
+                v:juice_up(0.1,0.1)
+                    v.ability.extra.mult = v.ability.extra.mult + (2 * G.GAME.soil_mod)
                     return true
                 end
             end

--- a/main.lua
+++ b/main.lua
@@ -37,7 +37,7 @@ Game.init_game_object = function(self)
     ret.current_round.marco_polo_pos = 1
     ret.current_round.go_fish = {
         rank = "Ace",
-        mult = 4
+        mult = 8
     }
     ret.current_round.zombie_target = nil
 
@@ -152,7 +152,7 @@ function SMODS.current_mod.reset_game_globals(run_start)
                 new_mult = new_mult + 1
             end
         end
-        G.GAME.current_round.go_fish.mult = new_mult
+        G.GAME.current_round.go_fish.mult = new_mult * 2
     end
 
     -- Zombie
@@ -1521,7 +1521,7 @@ SMODS.Joker { -- Clown Car
     key = 'clown_car',
     loc_txt = {
         name = 'Clown Car',
-        text = { 'Gains {C:mult}+2{} Mult each time', 'a Joker is added to hand', '{C:inactive}Currently: +#1#' }
+        text = { 'Gains {C:mult}+2{} Mult each time', 'a Joker is picked up', '{C:inactive}Currently: +#1#' }
     },
     atlas = 'Jokers',
     pos = {
@@ -2276,7 +2276,7 @@ SMODS.Joker { -- Go Fish
     loc_txt = {
         name = 'Go Fish',
         text = { '{C:mult}+2{} Mult for each {C:attention}#1#{}', 'in full deck at start of round',
-            '{C:inactive}Rank changes every round' }
+            '{C:inactive}Rank changes every round', '{C:inactive}Currently {C:mult}+#2# {C:inactive}Mult' }
     },
     atlas = 'Jokers',
     pos = {
@@ -2288,7 +2288,7 @@ SMODS.Joker { -- Go Fish
     blueprint_compat = true,
     loc_vars = function(self, info_queue, center)
         return {
-            vars = { G.GAME.current_round.go_fish.rank }
+            vars = { G.GAME.current_round.go_fish.rank, G.GAME.current_round.go_fish.mult }
         }
     end,
     calculate = function(self, card, context)
@@ -2822,7 +2822,7 @@ SMODS.Joker { -- Chihuahua
     key = 'chihuahua',
     loc_txt = {
         name = 'Chihuahua',
-        text = { 'Retriggers cards with ranks that appear', 'the least number of times', 'in the deck the', 'same number of times', 'that rank appears', '{C:inactive}Does not activate if there is a tie{}' }
+        text = { 'Retriggers cards with ranks that appear', 'the least number of times in the deck the', 'same number of times that rank appears', '{C:inactive}Does not activate if there is a tie{}' }
     },
     atlas = 'Jokers',
     pos = {

--- a/main.lua
+++ b/main.lua
@@ -864,7 +864,7 @@ SMODS.Joker { -- Streaker
 
         if context.before and not context.blueprint then
             card.ability.extra.hands = card.ability.extra.hands + 1
-            if card.ability.hands > 1 then
+            if card.ability.hands > 1 and card.ability.extra.streak ~= 0 then
                 card.ability.extra.streak = 0
                 card.ability.extra.chips = 0
                 card.ability.extra.mult = 0

--- a/main.lua
+++ b/main.lua
@@ -2669,7 +2669,7 @@ SMODS.Joker { -- Zombie
     key = 'zombie',
     loc_txt = {
         name = 'Zombie',
-        text = { 'Copies {C:attention}one random Joker{} each round.', 'The copied joker will {C:attention}turn into', '{C:attention}another Zombie{} at the end of the round', '{C:inactive}All zombies target the same Joker', '{C:inactive}Zombification can be stopped by selling all other zombies', '{C:inactive}Current target: {C:red}#1#{}' }
+        text = { 'Copies the effect of {C:attention}one random Joker{}', 'each round. The target Joker will {C:attention}turn into', '{C:attention}another Zombie{} at the end of the round', '{C:inactive}All zombies target the same Joker', '{C:inactive}Zombification can be stopped by selling all other zombies', '{C:inactive}Current target: {C:red}#1#{}' }
     },
     atlas = 'Jokers',
     pos = {

--- a/main.lua
+++ b/main.lua
@@ -185,13 +185,10 @@ function SMODS.current_mod.reset_game_globals(run_start)
                 local new_target = G.GAME.current_round.zombie_target
                 if #G.jokers.cards <= 1 then
                     new_target = nil
-                    sendDebugMessage('No valid jokers for zombies to target, skipping', 'MaximusDebug')
                 else
                     for i = 1, #G.jokers.cards do
                         if G.jokers.cards[i].config.center.key ~= 'j_mxms_zombie' and G.jokers.cards[i] ~= new_target and G.jokers.cards[i].config.center.blueprint_compat then
                             eligible_jokers[#eligible_jokers + 1] = G.jokers.cards[i]
-                            sendDebugMessage(G.jokers.cards[i].ability.name .. ' detected as an eligible zombie target',
-                                'MaximusDebug')
                         end
                     end
                     if next(eligible_jokers) then
@@ -204,8 +201,6 @@ function SMODS.current_mod.reset_game_globals(run_start)
 
                 G.GAME.current_round.zombie_target = new_target
                 if G.GAME.current_round.zombie_target ~= nil then
-                    sendDebugMessage(G.GAME.current_round.zombie_target.ability.name .. ' selected as zombie target',
-                        'MaximusDebug')
                     card_eval_status_text(G.GAME.current_round.zombie_target, 'extra', nil, nil, nil,
                         { message = 'Infected!', colour = G.C.GREEN })
                 end

--- a/main.lua
+++ b/main.lua
@@ -2,14 +2,14 @@
 Maximus_config = SMODS.current_mod.config
 
 -- Joker Sprite Atlases
-SMODS.Atlas {
+SMODS.Atlas { -- Main Joker Atlas
     key = 'Jokers',
     path = "Jokers.png",
     px = 71,
     py = 95
 }
 
-SMODS.Atlas {
+SMODS.Atlas { -- 4D Joker Atlas
     key = '4D',
     path = "4d_joker.png",
     px = 71,
@@ -156,24 +156,63 @@ function SMODS.current_mod.reset_game_globals(run_start)
     end
 
     -- Zombie
-    local eligible_jokers = {}
-    local new_target = G.GAME.current_round.zombie_target
-    if #G.jokers.cards <= 1 then
-        new_target = nil
-    else
-        for i = 1, #G.jokers.cards do
-            if G.jokers.cards[i].config.center.key ~= 'j_mxms_zombie' then
-                eligible_jokers[#eligible_jokers + 1] = G.jokers.cards[i]
+    if next(SMODS.find_card('j_mxms_zombie')) and G.GAME.current_round.zombie_target ~= nil then
+        G.E_MANAGER:add_event(Event({
+            func = function()
+                play_sound('timpani')
+                delay(0.4)
+                G.GAME.current_round.zombie_target.T.r = -0.2
+                G.GAME.current_round.zombie_target:juice_up(0.3, 0.4)
+                G.GAME.current_round.zombie_target.states.drag.is = true
+                G.GAME.current_round.zombie_target.children.center.pinch.x = true
+                local new_zombie = create_card('Joker', G.jokers, nil, nil, nil, nil, 'j_mxms_zombie',
+                    'zombie')
+                new_zombie:start_materialize()
+                new_zombie:add_to_deck()
+                G.jokers:emplace(new_zombie)
+                delay(0.4)
+                card_eval_status_text(new_zombie, 'extra', nil, nil, nil, { message = 'Turned!', colour = G.C.GREEN })
+                return true
             end
-        end
-        if next(eligible_jokers) then
-            new_target = pseudorandom_element(eligible_jokers, pseudoseed('zombie' .. G.GAME.round_resets.ante))
-        else
-            new_target = nil
-        end
+        }))
     end
 
-    G.GAME.current_round.zombie_target = new_target
+    if not next(SMODS.find_card('j_mxms_stop_sign')) then
+        G.E_MANAGER:add_event(Event({
+            trigger = 'after',
+            func = function()
+                local eligible_jokers = {}
+                local new_target = G.GAME.current_round.zombie_target
+                if #G.jokers.cards <= 1 then
+                    new_target = nil
+                    sendDebugMessage('No valid jokers for zombies to target, skipping', 'MaximusDebug')
+                else
+                    for i = 1, #G.jokers.cards do
+                        if G.jokers.cards[i].config.center.key ~= 'j_mxms_zombie' and G.jokers.cards[i] ~= new_target and G.jokers.cards[i].config.center.blueprint_compat then
+                            eligible_jokers[#eligible_jokers + 1] = G.jokers.cards[i]
+                            sendDebugMessage(G.jokers.cards[i].ability.name .. ' detected as an eligible zombie target',
+                                'MaximusDebug')
+                        end
+                    end
+                    if next(eligible_jokers) then
+                        new_target = pseudorandom_element(eligible_jokers,
+                            pseudoseed('zombie' .. G.GAME.round_resets.ante))
+                    else
+                        new_target = nil
+                    end
+                end
+
+                G.GAME.current_round.zombie_target = new_target
+                if G.GAME.current_round.zombie_target ~= nil then
+                    sendDebugMessage(G.GAME.current_round.zombie_target.ability.name .. ' selected as zombie target',
+                        'MaximusDebug')
+                    card_eval_status_text(G.GAME.current_round.zombie_target, 'extra', nil, nil, nil,
+                        { message = 'Infected!', colour = G.C.GREEN })
+                end
+                return true
+            end
+        }))
+    end
 end
 
 -- Update checks
@@ -256,7 +295,8 @@ SMODS.Joker { -- Fortune Cookie
         -- Activate ability before scoring if chance is higher than 0
         if context.before and card.ability.extra.chance > 0 then
             -- Roll chance and decrease by 1
-            local chance_roll = pseudorandom('fco', 1, 10 * G.GAME.fridge_mod * G.GAME.probabilities.normal)
+            local chance_roll = pseudorandom('fco' .. G.GAME.round_resets.ante, 1,
+                10 * G.GAME.fridge_mod * G.GAME.probabilities.normal)
             local chance_odds = (card.ability.extra.odds - card.ability.extra.chance) * G.GAME.fridge_mod
             card.ability.extra.chance = card.ability.extra.chance - (1 / G.GAME.fridge_mod)
 
@@ -517,10 +557,11 @@ SMODS.Joker { -- Abyss
             else
                 -- Choose Joker to affect
                 local chosen_joker =
-                    #eligible_jokers > 0 and pseudorandom_element(eligible_jokers, pseudoseed('abyss')) or nil
+                    #eligible_jokers > 0 and
+                    pseudorandom_element(eligible_jokers, pseudoseed('abyss' .. G.GAME.round_resets.ante)) or nil
 
                 -- "Flip a coin" to decide what to do with the target
-                local flip = pseudorandom('aby', 1, 2)
+                local flip = pseudorandom('aby' .. G.GAME.round_resets.ante, 1, 2)
 
                 -- Add negative edition to random held joker
                 if flip == 1 then
@@ -789,7 +830,7 @@ SMODS.Joker { -- Streaker
     key = 'streaker',
     loc_txt = {
         name = 'Streaker',
-        text = { '{C:chips}+20{} Chips and {C:mult}+8{} Mult', 'for each consecutive {C:attention}blind{}',
+        text = { '{C:chips}+20{} Chips and {C:mult}+5{} Mult', 'for each consecutive {C:attention}blind{}',
             'beaten in {C:attention}one hand{}, {C:red}Resets{}', 'when streak is broken',
             '{C:inactive}Current streak: #1#',
             '{C:inactive}Currently: {C:chips}+#3# {C:inactive}Chips, {C:mult}+#4#{} Mult' }
@@ -828,27 +869,27 @@ SMODS.Joker { -- Streaker
 
         if context.before and not context.blueprint then
             card.ability.extra.hands = card.ability.extra.hands + 1
-        end
-
-        if context.end_of_round and not context.blueprint and not context.repetition and not context.individual then
-            if card.ability.extra.hands == 1 then
-                card.ability.extra.hands = 0
-                card.ability.extra.streak = card.ability.extra.streak + 1
-                card.ability.extra.chips = 20 * card.ability.extra.streak * G.GAME.soil_mod
-                card.ability.extra.mult = 8 * card.ability.extra.streak * G.GAME.soil_mod
-                return {
-                    message = 'Streak ' .. card.ability.extra.streak,
-                    colour = G.C.CHIPS,
-                    card = card
-                }
-            else
+            if card.ability.hands > 1 then
                 card.ability.extra.streak = 0
-                card.ability.extra.hands = 0
                 card.ability.extra.chips = 0
                 card.ability.extra.mult = 0
                 return {
                     message = localize('k_reset'),
                     colour = G.C.RED,
+                    card = card
+                }
+            end
+        end
+
+        if context.end_of_round and not context.blueprint and not context.repetition and not context.individual then
+            card.ability.extra.hands = 0
+            if card.ability.extra.hands == 1 then
+                card.ability.extra.streak = card.ability.extra.streak + 1
+                card.ability.extra.chips = 20 * card.ability.extra.streak * G.GAME.soil_mod
+                card.ability.extra.mult = 5 * card.ability.extra.streak * G.GAME.soil_mod
+                return {
+                    message = 'Streak ' .. card.ability.extra.streak,
+                    colour = G.C.CHIPS,
                     card = card
                 }
             end
@@ -915,7 +956,7 @@ SMODS.Joker { -- Jobber
 
                 -- Choose Joker to copy
                 local chosen_joker = #eligible_jokers > 0 and
-                    pseudorandom_element(eligible_jokers, pseudoseed('jobber')) or nil
+                    pseudorandom_element(eligible_jokers, pseudoseed('jobber' .. G.GAME.round_resets.ante)) or nil
 
                 -- Copy Joker and add to hand
                 local new_card = copy_card(chosen_joker, nil, nil, nil,
@@ -1211,7 +1252,7 @@ SMODS.Joker { -- Chef
             local chosen_joker = nil
             while not chosen_joker or
                 (chosen_joker.name == 'Cavendish' and not G.GAME.pool_flags.gros_michel_extinct) do
-                chosen_joker = pseudorandom_element(food_jokers, pseudoseed('chef'))
+                chosen_joker = pseudorandom_element(food_jokers, pseudoseed('chef' .. G.GAME.round_resets.ante))
             end
             local new_card = create_card('Joker', G.jokers, nil, nil, nil, nil, chosen_joker.key, 'chef')
             new_card:add_to_deck()
@@ -1323,7 +1364,7 @@ SMODS.Joker { -- Hopscotch
     end,
     calculate = function(self, card, context)
         if context.setting_blind and not G.GAME.blind:get_type() == 'Boss' and not context.blueprint then
-            if pseudorandom('hopscotch', G.GAME.probabilities.normal, 3) == 3 then
+            if pseudorandom('hopscotch' .. G.GAME.round_resets.ante, G.GAME.probabilities.normal, 3) == 3 then
                 -- Code derived from G.FUNCS.skip_blind
                 local _tag = G.GAME.skip_tag
                 if _tag then
@@ -1673,7 +1714,7 @@ SMODS.Joker { -- Dark Room
             end
 
             local chosen_voucher = create_card('Voucher', nil, nil, nil, nil, nil,
-                pseudorandom_element(eligible_vouchers, pseudoseed('dark_room')), 'dark_room')
+                pseudorandom_element(eligible_vouchers, pseudoseed('dark_room' .. G.GAME.round_resets.ante)), 'dark_room')
             chosen_voucher.cost = 0
             chosen_voucher:redeem()
             G.E_MANAGER:add_event(Event({
@@ -1874,7 +1915,8 @@ SMODS.Joker { -- Random Encounter
     end,
     calculate = function(self, card, context)
         if context.individual and context.cardarea == G.play then
-            local chance_roll = pseudorandom('rand_enc', card.ability.extra.chance * G.GAME.probabilities.normal, 4)
+            local chance_roll = pseudorandom('rand_enc' .. G.GAME.round_resets.ante,
+                card.ability.extra.chance * G.GAME.probabilities.normal, 4)
             if chance_roll == 4 then
                 G.E_MANAGER:add_event(Event({
                     trigger = 'before',
@@ -2115,7 +2157,7 @@ SMODS.Joker { -- Salt Circle
     key = 'salt_circle',
     loc_txt = {
         name = 'Salt Circle',
-        text = { 'Gains {C:chips}+15{} Chips for', 'for every {C:spectral}Spectral{} card used',
+        text = { 'Gains {C:chips}+30{} Chips for', 'for every {C:spectral}Spectral{} card used',
             '{C:inactive}Currently: {C:chips}+#1#' }
     },
     atlas = 'Jokers',
@@ -2128,14 +2170,14 @@ SMODS.Joker { -- Salt Circle
     blueprint_compat = true,
     loc_vars = function(self, info_queue, center)
         return {
-            vars = { G.GAME.spectrals_used * 15 }
+            vars = { G.GAME.spectrals_used * 30 }
         }
     end,
     calculate = function(self, card, context)
         if context.joker_main and G.GAME.spectrals_used > 0 then
             return {
-                chip_mod = G.GAME.spectrals_used * 15,
-                message = '+' .. G.GAME.spectrals_used * 15,
+                chip_mod = G.GAME.spectrals_used * 30,
+                message = '+' .. G.GAME.spectrals_used * 30,
                 colour = G.C.MULT,
                 card = card
             }
@@ -2183,7 +2225,7 @@ SMODS.Joker { -- Monk
     key = 'monk',
     loc_txt = {
         name = 'Monk',
-        text = { 'Gains {C:chips}+20{} chips for every', 'shop exited without purchase',
+        text = { 'Gains {C:chips}+25{} chips for every', 'shop exited without purchase',
             '{C:inactive}Currently: {C:chips}+#1#{}' }
     },
     atlas = 'Jokers',
@@ -2215,14 +2257,13 @@ SMODS.Joker { -- Monk
         end
 
         if (context.buying_card or context.open_booster or context.reroll_shop) and not context.blueprint then
-            sendDebugMessage('Purchase detected! Monk will not trigger', 'MaximusDebug')
             card.ability.extra.purchase_made = true
         end
 
         if context.ending_shop and not card.ability.extra.purchase_made then
             card:juice_up(0.3, 0.4)
             play_sound('tarot1')
-            card.ability.extra.chips = card.ability.extra.chips + (20 * G.GAME.soil_mod)
+            card.ability.extra.chips = card.ability.extra.chips + (25 * G.GAME.soil_mod)
         end
 
         if context.setting_blind then
@@ -2633,7 +2674,7 @@ SMODS.Joker { -- Zombie
     key = 'zombie',
     loc_txt = {
         name = 'Zombie',
-        text = { 'Copies {C:attention}one random Joker{} each round.', 'The copied joker will {C:attention}turn into', '{C:attention}another Zombie{} at the end', 'of the round', '{C:inactive}All zombies target the same Joker', '{C:inactive}Zombification can be stopped by selling', '{C:inactive}the zombie that made the copy' }
+        text = { 'Copies {C:attention}one random Joker{} each round.', 'The copied joker will {C:attention}turn into', '{C:attention}another Zombie{} at the end of the round', '{C:inactive}All zombies target the same Joker', '{C:inactive}Zombification can be stopped by selling all other zombies', '{C:inactive}Current target: {C:red}#1#{}' }
     },
     atlas = 'Jokers',
     pos = {
@@ -2641,56 +2682,32 @@ SMODS.Joker { -- Zombie
         y = 5
     },
     rarity = 2,
-    config = {
-        extra = {
-            infected = nil
-        }
-    },
+    config = {},
     blueprint_compat = true,
-    calculate = function(self, card, context)
-        if context.setting_blind and G.GAME.current_round.zombie_target ~= nil and #G.jokers.cards + G.GAME.joker_buffer < G.jokers.config.card_limit then
-            G.GAME.joker_buffer = G.GAME.joker_buffer + 1
-            G.E_MANAGER:add_event(Event({
-                func = function()
-                    G.E_MANAGER:add_event(Event({
-                        func = function()
-                            play_sound('timpani')
-                            delay(0.4)
-                            card.ability.extra.infected = copy_card(G.GAME.current_round.zombie_target, nil, nil, nil,
-                                nil)
-                            card.ability.extra.infected:start_materialize()
-                            card.ability.extra.infected:add_to_deck()
-                            G.jokers:emplace(card.ability.extra.infected)
-                            return true
-                        end
-                    }))
-                    card_eval_status_text(card, 'extra', nil, nil, nil, { message = 'Infected!' })
-                    return true
-                end
-            }))
-            G.GAME.joker_buffer = G.GAME.joker_buffer - 1
+    loc_vars = function(self, info_queue, center)
+        if G.GAME.current_round.zombie_target ~= nil then
+            return {
+                vars = { G.localization.descriptions.Joker[G.GAME.current_round.zombie_target.config.center.key].name }
+            }
+        else
+            return {
+                vars = { 'No valid target' }
+            }
         end
-
-        if context.end_of_round and not context.individual and not context.repetition and card.ability.extra.infected ~= nil and not (card.ability.extra.infected.abililty and card.ability.extra.infected.abililty.eternal) then
-            G.E_MANAGER:add_event(Event({
-                func = function()
-                    G.E_MANAGER:add_event(Event({
-                        func = function()
-                            play_sound('timpani')
-                            delay(0.4)
-                            card.ability.extra.infected:start_dissolve({ G.C.GREEN }, nil, 1.6)
-                            local new_zombie = create_card('Joker', G.jokers, nil, nil, nil, nil, 'j_mxms_zombie',
-                                'zombie')
-                            new_zombie:start_materialize()
-                            new_zombie:add_to_deck()
-                            G.jokers:emplace(new_zombie)
-                            return true
-                        end
-                    }))
-                    card_eval_status_text(card, 'extra', nil, nil, nil, { message = 'Turned!' })
-                    return true
-                end
-            }))
+    end,
+    calculate = function(self, card, context)
+        if G.GAME.current_round.zombie_target and not context.no_blueprint then
+            context.blueprint = (context.blueprint and (context.blueprint + 1)) or 1
+            context.blueprint_card = context.blueprint_card or card
+            local zombie_target_ret = G.GAME.current_round.zombie_target:calculate_joker(context)
+            context.blueprint = nil
+            local eff_card = context.blueprint_card or self
+            context.blueprint_card = nil
+            if zombie_target_ret then
+                zombie_target_ret.card = eff_card
+                zombie_target_ret.colour = G.C.GREEN
+                return zombie_target_ret
+            end
         end
     end
 }
@@ -2822,7 +2839,7 @@ SMODS.Joker { -- Chihuahua
     key = 'chihuahua',
     loc_txt = {
         name = 'Chihuahua',
-        text = { 'Retriggers cards with ranks that appear', 'the least number of times in the deck the', 'same number of times that rank appears', '{C:inactive}Does not activate if there is a tie{}' }
+        text = { 'Retriggers cards with ranks that appear', 'the least number of times in the deck the', 'same number of times that rank appears', '{C:inactive}Does not activate if there is a tie{}', '{C:inactive}Limit of 10 retriggers{}' }
     },
     atlas = 'Jokers',
     pos = {
@@ -2877,9 +2894,15 @@ SMODS.Joker { -- Chihuahua
         end
 
         if context.cardarea == G.play and context.repetition and tostring(context.other_card.base.id) == card.ability.extra.least_id and not card.ability.extra.tie then
+            local reps 
+            if card.ability.extra.least_count <= 10 then
+                reps = card.ability.extra.least_count
+            else
+                reps = 10
+            end
             return {
                 message = localize('k_again_ex'),
-                repetitions = card.ability.extra.least_count,
+                repetitions = reps,
                 card = card
             }
         end
@@ -2933,7 +2956,8 @@ SMODS.Joker { -- Ledger
             else
                 -- Choose Joker to affect
                 local chosen_joker =
-                    #eligible_jokers > 0 and pseudorandom_element(eligible_jokers, pseudoseed('abyss')) or nil
+                    #eligible_jokers > 0 and
+                    pseudorandom_element(eligible_jokers, pseudoseed('ledger' .. G.GAME.round_resets.ante)) or nil
 
                 -- Add negative edition to random held joker
 


### PR DESCRIPTION
Zombie: Now acts like a blueprint of target card. Target card gets converted to Zombie after round ends unless ALL zombies are sold

Chihuahua: Retriggers now capped at 10

Coupon: Chances increased to 1 in 10

Streaker: Mult iteration decreased from +8 to +5. Now resets as soon as a second hand in a round is played

Salt Circle: Chip iteration increased from +15 to +30

Monk: Chip iteration increased from +20 to +25