### PR TITLE
Patch v0.1.5

### DIFF
--- a/Maximus.json
+++ b/Maximus.json
@@ -9,6 +9,6 @@
 	"priority": 0,
 	"badge_colour": "f51bbc",
 	"badge_text_colour": "f8a100",
-	"version": "0.1.4-beta",
+	"version": "0.1.5-beta",
 	"dependencies": []
 }

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -23,7 +23,7 @@ return {
                 name="Sixth Sense",
                 text={
                     "If {C:attention}first hand{} of round is",
-                    "#1# {C:attention}Six(es){}, destroy the card(s)",
+                    "at most #1# {C:attention}Six(es){}, destroy the card(s)",
                     "and create a {C:spectral}Spectral{} card",
                     "{C:inactive}(Must have room)",
                 },

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -23,7 +23,7 @@ return {
                 name="Sixth Sense",
                 text={
                     "If {C:attention}first hand{} of round is",
-                    "#1# or less {C:attention}6's{}, destroy the card(s)",
+                    "#1# {C:attention}Six(es){}, destroy the card(s)",
                     "and create a {C:spectral}Spectral{} card",
                     "{C:inactive}(Must have room)",
                 },

--- a/lovely.toml
+++ b/lovely.toml
@@ -84,7 +84,22 @@ end
 match_indent = true
 times = 2
 
-
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if next(find_joker('Smeared Joker')) and (self.base.suit == 'Hearts' or self.base.suit == 'Diamonds') == (suit == 'Hearts' or suit == 'Diamonds') then
+    return true
+end
+'''
+position = "before"
+payload = '''
+if next(SMODS.find_card('j_mxms_faded')) and next(find_joker('Smeared Joker')) then
+    return true
+end
+'''
+match_indent = true
+times = 2
 
 
 

--- a/lovely.toml
+++ b/lovely.toml
@@ -1696,8 +1696,15 @@ position = "at"
 payload = '''
 if polled_rate > check_rate and polled_rate <= check_rate + v.val then
     local card = create_card(v.type, area, nil, nil, nil, nil, nil, 'sho')
-    if card.ability.set == 'Joker' and next(SMODS.find_card('j_mxms_coupon')) and pseudorandom('cou' .. G.GAME.round_resets.ante, 1 * G.GAME.probabilities.normal, 10) == 10 then
-        card.cost = 0
+    local coupons = SMODS.find_card('j_mxms_coupon')
+    if card.ability.set == 'Joker' and next(coupons) then
+        for k, v in pairs(coupons) do
+            if pseudorandom('cou' .. G.GAME.round_resets.ante, 1 * G.GAME.probabilities.normal, 10) == 10 then
+                card.cost = 0
+                v:juice_up(0.3, 0.4)
+                break
+            end
+        end
     end
 '''
 match_indent = true

--- a/lovely.toml
+++ b/lovely.toml
@@ -585,6 +585,35 @@ match_indent = true
 times = 1
 
 
+    # Add flag to Glass Card Break
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if scoring_hand[i].ability.name == 'Glass Card' and not scoring_hand[i].debuff and pseudorandom('glass') < G.GAME.probabilities.normal/scoring_hand[i].ability.extra then 
+    destroyed = true
+'''
+position = "after"
+payload = '''
+if next(SMODS.find_card('j_mxms_pessimistic')) then
+    for k, v in pairs(G.jokers.cards) do
+        if v.config.center.key == 'j_mxms_pessimistic' then
+            v.ability.extra.mult = v.ability.extra.mult + ((self.ability.extra - G.GAME.probabilities.normal) * G.GAME.soil_mod)
+            G.E_MANAGER:add_event(Event({
+                trigger = 'after',
+                func = function()
+                    v:juice_up(0.3, 0.4)
+                return true; end
+            }))
+            
+        end
+    end
+end
+'''
+match_indent = true
+times = 1
+
+
     # Add flag to Hallucination
 [[patches]]
 [patches.pattern]

--- a/lovely.toml
+++ b/lovely.toml
@@ -588,7 +588,7 @@ times = 1
     # Add flag to Glass Card Break
 [[patches]]
 [patches.pattern]
-target = "card.lua"
+target = "functions/state_events.lua"
 pattern = '''
 if scoring_hand[i].ability.name == 'Glass Card' and not scoring_hand[i].debuff and pseudorandom('glass') < G.GAME.probabilities.normal/scoring_hand[i].ability.extra then 
     destroyed = true

--- a/lovely.toml
+++ b/lovely.toml
@@ -234,7 +234,38 @@ match_indent = true
 times = 1
 
 
+    #Change limits for Grim, Incantation, and Familiar
+[[patches]]
+[patches.pattern]
+target = '=[SMODS _ "src/game_object.lua"]'
+pattern = '''
+local function random_destroy(used_tarot)
+    local destroyed_cards = {}
+    destroyed_cards[#destroyed_cards + 1] = pseudorandom_element(G.hand.cards, pseudoseed('random_destroy'))
+'''
+position = "at"
+payload = '''
+local function random_destroy(used_tarot)
+    local destroyed_cards = {}
+    for i = 1, used_tarot.ability.destroy * G.GAME.war_mod do
+        destroyed_cards[#destroyed_cards + 1] = pseudorandom_element(G.hand.cards, pseudoseed('random_destroy'..i))
+        sendDebugMessage("Destroyed card via consumeable","MaximusDebug")
+    end
+'''
+match_indent = true
+times = 1
+
+
     #Change descriptions for Grim, Incantation, and Familiar
+[[patches]]
+[patches.pattern]
+target = "functions/common_events.lua"
+pattern = "if _c.name == 'Familiar' or _c.name == 'Grim' or _c.name == 'Incantation' then loc_vars = {cfg.extra}"
+position = "at"
+payload = "if _c.name == 'Familiar' or _c.name == 'Grim' or _c.name == 'Incantation' then loc_vars = {cfg.extra, cfg.destroy * G.GAME.war_mod}"
+match_indent = true
+times = 1
+
 [[patches]]
 [patches.pattern]
 target = "game.lua"
@@ -249,15 +280,6 @@ c_familiar=         {order = 1,    discovered = false, cost = 4, consumeable = t
 c_grim=             {order = 2,    discovered = false, cost = 4, consumeable = true, name = "Grim",     pos = {x=1,y=4}, set = "Spectral", config = {remove_card = true, extra = 2, destroy = 1}},
 c_incantation=      {order = 3,    discovered = false, cost = 4, consumeable = true, name = "Incantation", pos = {x=2,y=4}, set = "Spectral", config = {remove_card = true, extra = 4, destroy = 1}},
 '''
-match_indent = true
-times = 1
-
-[[patches]]
-[patches.pattern]
-target = "functions/common_events.lua"
-pattern = "if _c.name == 'Familiar' or _c.name == 'Grim' or _c.name == 'Incantation' then loc_vars = {cfg.extra}"
-position = "at"
-payload = "if _c.name == 'Familiar' or _c.name == 'Grim' or _c.name == 'Incantation' then loc_vars = {cfg.extra, cfg.destroy * G.GAME.war_mod}"
 match_indent = true
 times = 1
 
@@ -605,23 +627,28 @@ times = 1
 [patches.pattern]
 target = "functions/state_events.lua"
 pattern = '''
-if scoring_hand[i].ability.name == 'Glass Card' and not scoring_hand[i].debuff and pseudorandom('glass') < G.GAME.probabilities.normal/scoring_hand[i].ability.extra then 
-    destroyed = true
+for k, v in ipairs(cards_destroyed) do
+    if v.shattered then glass_shattered[#glass_shattered+1] = v end
+end
 '''
-position = "after"
+position = "at"
 payload = '''
-if next(SMODS.find_card('j_mxms_pessimistic')) then
-    for k, v in pairs(G.jokers.cards) do
-        if v.config.center.key == 'j_mxms_pessimistic' then
-            v.ability.extra.mult = v.ability.extra.mult + ((self.ability.extra - G.GAME.probabilities.normal) * G.GAME.soil_mod)
-            G.E_MANAGER:add_event(Event({
-                trigger = 'after',
-                func = function()
-                    v:juice_up(0.3, 0.4)
-                return true; end
-            }))
-            
-        end
+local pessimistics = SMODS.find_card('j_mxms_pessimistic')
+for k, v in ipairs(cards_destroyed) do
+    if v.shattered then 
+    glass_shattered[#glass_shattered+1] = v 
+    if next(pessimistics) then
+    for kk, vv in pairs(pessimistics) do
+        vv.ability.extra.mult = vv.ability.extra.mult + ((self.ability.extra - G.GAME.probabilities.normal) * G.GAME.soil_mod)
+        G.E_MANAGER:add_event(Event({
+            trigger = 'after',
+            func = function()
+                vv:juice_up(0.3, 0.4)
+            return true; end
+        }))
+    end
+end
+
     end
 end
 '''
@@ -679,7 +706,7 @@ payload = '''
 if next(SMODS.find_card('j_mxms_pessimistic')) then
     for k, v in pairs(G.jokers.cards) do
         if v.config.center.key == 'j_mxms_pessimistic' then
-            v.ability.extra.mult = v.ability.extra.mult + ((self.ability.extra - G.GAME.probabilities.normal) * G.GAME.soil_mod)
+            v.ability.extra.mult = v.ability.extra.mult + ((self.ability.extra.odds - G.GAME.probabilities.normal) * G.GAME.soil_mod)
             G.E_MANAGER:add_event(Event({
                 trigger = 'after',
                 func = function()
@@ -1517,7 +1544,7 @@ times = 1
 
 
 
-# Add Random Encounter Functionality -----------------------------------------
+# Add mult bonus variable to card objects-----------------------------------------
 
     # Create card variable
 [[patches]]
@@ -1624,7 +1651,7 @@ function get_flush(hand)
   local ret = {}
   local four_fingers = next(find_joker('Four Fingers'))
   local suits = SMODS.Suit.obj_buffer
-if #hand < (5 - (four_fingers and 1 or 0)) then return ret else
+  if #hand < (5 - (four_fingers and 1 or 0)) then return ret else
 '''
 position = "at"
 payload = '''
@@ -1633,7 +1660,7 @@ function get_flush(hand)
   local four_fingers = next(find_joker('Four Fingers'))
   local virus = next(SMODS.find_card('j_mxms_virus'))
   local suits = SMODS.Suit.obj_buffer
-if #hand < (5 - (four_fingers and 1 or virus and 3 or 0)) then return ret else
+  if #hand < (5 - (four_fingers and 1 or virus and 3 or 0)) then return ret else
 '''
 match_indent = true
 times = 1

--- a/lovely.toml
+++ b/lovely.toml
@@ -249,7 +249,6 @@ local function random_destroy(used_tarot)
     local destroyed_cards = {}
     for i = 1, used_tarot.ability.destroy * G.GAME.war_mod do
         destroyed_cards[#destroyed_cards + 1] = pseudorandom_element(G.hand.cards, pseudoseed('random_destroy'..i))
-        sendDebugMessage("Destroyed card via consumeable","MaximusDebug")
     end
 '''
 match_indent = true

--- a/lovely.toml
+++ b/lovely.toml
@@ -20,12 +20,13 @@ times = 1
 
     # Add modifier to definitions
 [[patches]]
-[patches.regex]
-target = "functions/common_events.lua"
-pattern = "(cfg.choose)"
-position = "after"
-payload = " + G.GAME.choose_mod"
-times = 15
+[patches.pattern]
+target = '=[SMODS _ "src/game_object.lua"]'
+pattern = 'vars = { cfg.choose, cfg.extra },'
+position = "at"
+payload = 'vars = { cfg.choose + G.GAME.choose_mod, cfg.extra },'
+match_indent = true
+timer = 1
 
 
 

--- a/lovely.toml
+++ b/lovely.toml
@@ -1131,17 +1131,6 @@ times = 1
 
 # Hopscotch Functionality --------------------------------------
 
-    # Create tracking variable
-[[patches]]
-[patches.pattern]
-target = "game.lua"
-pattern = "pack_size = 2,"
-position = "after"
-payload = "skip_tag = '',"
-match_indent = true
-times = 1
-
-
     # Intercept skip tag from 
 [[patches]]
 [patches.pattern]

--- a/lovely.toml
+++ b/lovely.toml
@@ -1309,7 +1309,7 @@ match_indent = true
 times = 1
 
 
-    # Change Raise Fist interaction
+    # Change Raised Fist interaction
 [[patches]]
 [patches.pattern]
 target = "card.lua"
@@ -1318,7 +1318,7 @@ if temp_ID >= G.hand.cards[i].base.id and not SMODS.has_no_rank(G.hand.cards[i])
 '''
 position = "at"
 payload = '''
-if temp_ID >= (G.hand.cards[i].base.id and not SMODS.has_no_rank(G.hand.cards[i])) or next(SMODS.find_card('j_mxms_hammer_and_chisel')) then
+if (temp_ID >= G.hand.cards[i].base.id and not SMODS.has_no_rank(G.hand.cards[i])) or next(SMODS.find_card('j_mxms_hammer_and_chisel')) then
 '''
 match_indent = true
 times = 1

--- a/main.lua
+++ b/main.lua
@@ -1,6 +1,9 @@
 -- Load config and save state
 Maximus_config = SMODS.current_mod.config
 
+--SMODS Optional Features
+SMODS.current_mod.optional_features = { retrigger_joker = true }
+
 
 -- Joker Sprite Atlases
 SMODS.Atlas { -- Main Joker Atlas
@@ -701,7 +704,6 @@ SMODS.Joker { -- Microwave
                     }
                 end
             end
-            sendDebugMessage(context.other_card.config.center.key .. ' is not applicable to Microwave', 'MaximusDebug')
         end
     end
 }

--- a/main.lua
+++ b/main.lua
@@ -31,6 +31,7 @@ Game.init_game_object = function(self)
     ret.spectrals_used = 0
     ret.creep_mod = 1
     ret.soil_mod = 1
+    ret.skip_tag = ''
 
     --Rotating Modifiers
     ret.current_round.impractical_hand = 'High Card'
@@ -333,7 +334,7 @@ SMODS.Joker { -- Fortune Cookie
         -- Activate ability before scoring if chance is higher than 0
         if context.before and card.ability.extra.chance > 0 then
             -- Roll chance and decrease by 1
-            local chance_roll = pseudorandom('fco' .. G.GAME.round_resets.ante, 1,
+            local chance_roll = pseudorandom(('fco' .. G.GAME.round_resets.ante), 1,
                 10 * G.GAME.fridge_mod * G.GAME.probabilities.normal)
             local chance_odds = (card.ability.extra.odds - card.ability.extra.chance) * G.GAME.fridge_mod
             card.ability.extra.chance = card.ability.extra.chance - (1 / G.GAME.fridge_mod)
@@ -601,7 +602,7 @@ SMODS.Joker { -- Abyss
                     pseudorandom_element(eligible_jokers, pseudoseed('abyss' .. G.GAME.round_resets.ante)) or nil
 
                 -- "Flip a coin" to decide what to do with the target
-                local flip = pseudorandom('aby' .. G.GAME.round_resets.ante, 1, 2)
+                local flip = pseudorandom(('aby' .. G.GAME.round_resets.ante), 1, 2)
 
                 -- Add negative edition to random held joker
                 if flip == 1 then
@@ -1406,7 +1407,7 @@ SMODS.Joker { -- Hopscotch
     key = 'hopscotch',
     loc_txt = {
         name = 'Hopscotch',
-        text = { 'When selecting blind,', '{C:green}1 out of 3{} chance to', 'receive associated skip tag' }
+        text = { 'When selecting blind,', '{C:green}#1# out of 3{} chance to', 'receive associated skip tag' }
     },
     atlas = 'Jokers',
     pos = {
@@ -1422,8 +1423,10 @@ SMODS.Joker { -- Hopscotch
         }
     end,
     calculate = function(self, card, context)
-        if context.setting_blind and not G.GAME.blind:get_type() == 'Boss' and not context.blueprint then
-            if pseudorandom('hopscotch' .. G.GAME.round_resets.ante, G.GAME.probabilities.normal, 3) == 3 then
+        if context.setting_blind and G.GAME.blind:get_type() ~= 'Boss' and not context.blueprint then
+            local chance_roll = pseudorandom(('hopscotch' .. G.GAME.round_resets.ante), G.GAME.probabilities.normal, 3)
+            if chance_roll == 3 then
+                sendDebugMessage("Hopscotch activated","MaximusDebug")
                 -- Code derived from G.FUNCS.skip_blind
                 local _tag = G.GAME.skip_tag
                 if _tag then
@@ -1988,7 +1991,7 @@ SMODS.Joker { -- Random Encounter
     end,
     calculate = function(self, card, context)
         if context.individual and context.cardarea == G.play then
-            local chance_roll = pseudorandom('rand_enc' .. G.GAME.round_resets.ante,
+            local chance_roll = pseudorandom(('rand_enc' .. G.GAME.round_resets.ante),
                 card.ability.extra.chance * G.GAME.probabilities.normal, 4)
             if chance_roll == 4 then
                 G.E_MANAGER:add_event(Event({

--- a/main.lua
+++ b/main.lua
@@ -132,7 +132,7 @@ function SMODS.current_mod.reset_game_globals(run_start)
             new_pos = 1
         else
             while new_pos == G.GAME.current_round.marco_polo_pos do
-                new_pos = pseudorandom(('marcopolo' .. G.GAME.round_resets.ante), 1, #G.jokers.cards)
+                new_pos = pseudorandom(pseudoseed('marcopolo' .. G.GAME.round_resets.ante), 1, #G.jokers.cards)
             end
         end
         G.GAME.current_round.marco_polo_pos = new_pos
@@ -334,7 +334,7 @@ SMODS.Joker { -- Fortune Cookie
         -- Activate ability before scoring if chance is higher than 0
         if context.before and card.ability.extra.chance > 0 then
             -- Roll chance and decrease by 1
-            local chance_roll = pseudorandom(('fco' .. G.GAME.round_resets.ante), 1,
+            local chance_roll = pseudorandom(pseudoseed('fco' .. G.GAME.round_resets.ante), 1,
                 10 * G.GAME.fridge_mod * G.GAME.probabilities.normal)
             local chance_odds = (card.ability.extra.odds - card.ability.extra.chance) * G.GAME.fridge_mod
             card.ability.extra.chance = card.ability.extra.chance - (1 / G.GAME.fridge_mod)
@@ -388,7 +388,7 @@ SMODS.Joker { -- Fortune Cookie
                     }))
                     return {
                         card = card,
-                        message = 'NOPE!',
+                        message = localize('k_nope_ex'),
                         colour = G.C.SET.Tarot
                     }
                 end
@@ -602,7 +602,7 @@ SMODS.Joker { -- Abyss
                     pseudorandom_element(eligible_jokers, pseudoseed('abyss' .. G.GAME.round_resets.ante)) or nil
 
                 -- "Flip a coin" to decide what to do with the target
-                local flip = pseudorandom(('aby' .. G.GAME.round_resets.ante), 1, 2)
+                local flip = pseudorandom(pseudoseed('aby' .. G.GAME.round_resets.ante), 1, 2)
 
                 -- Add negative edition to random held joker
                 if flip == 1 then
@@ -1424,9 +1424,8 @@ SMODS.Joker { -- Hopscotch
     end,
     calculate = function(self, card, context)
         if context.setting_blind and G.GAME.blind:get_type() ~= 'Boss' and not context.blueprint then
-            local chance_roll = pseudorandom(('hopscotch' .. G.GAME.round_resets.ante), G.GAME.probabilities.normal, 3)
+            local chance_roll = pseudorandom(pseudoseed('hopscotch' .. G.GAME.round_resets.ante), G.GAME.probabilities.normal, 3)
             if chance_roll == 3 then
-                sendDebugMessage("Hopscotch activated","MaximusDebug")
                 -- Code derived from G.FUNCS.skip_blind
                 local _tag = G.GAME.skip_tag
                 if _tag then
@@ -1455,8 +1454,22 @@ SMODS.Joker { -- Hopscotch
                         end
                     }))
                 end
-            elseif next(SMODS.find_card('j_mxms_pessimistic')) then
-                G.GAME.pessimistic_mult = G.GAME.pessimistic_mult + (3 - G.GAME.probabilities.normal)
+            else
+                if next(SMODS.find_card('j_mxms_pessimistic')) then
+                    G.GAME.pessimistic_mult = G.GAME.pessimistic_mult + (3 - G.GAME.probabilities.normal)
+                end
+                G.E_MANAGER:add_event(Event({
+                    trigger = 'before',
+                    func = function()
+                        play_sound('tarot2')
+                        return true;
+                    end
+                }))
+                return {
+                    card = card,
+                    message = localize('k_nope_ex'),
+                    colour = G.C.SET.Tarot
+                }
             end
         end
     end
@@ -1991,7 +2004,7 @@ SMODS.Joker { -- Random Encounter
     end,
     calculate = function(self, card, context)
         if context.individual and context.cardarea == G.play then
-            local chance_roll = pseudorandom(('rand_enc' .. G.GAME.round_resets.ante),
+            local chance_roll = pseudorandom(pseudoseed('rand_enc' .. G.GAME.round_resets.ante),
                 card.ability.extra.chance * G.GAME.probabilities.normal, 4)
             if chance_roll == 4 then
                 G.E_MANAGER:add_event(Event({

--- a/main.lua
+++ b/main.lua
@@ -1924,17 +1924,16 @@ SMODS.Joker { -- Unpleasant Gradient
     },
     rarity = 2,
     config = {},
-    blueprint_compat = true,
+    blueprint_compat = false,
     cost = 5,
     calculate = function(self, card, context)
         if context.before and not context.blueprint and #context.scoring_hand == 4 then
-            card:juice_up(0.3, 0.4)
 
             -- Code derived from Sigil
             for i = 1, #context.scoring_hand do
                 local percent = 1.15 - (i - 0.999) / (#context.scoring_hand - 0.998) * 0.3
                 G.E_MANAGER:add_event(Event({
-                    trigger = 'before',
+                    trigger = 'after',
                     delay = 0.15,
                     func = function()
                         local other_card = context.scoring_hand[i]
@@ -1958,7 +1957,7 @@ SMODS.Joker { -- Unpleasant Gradient
                     end
                 }))
             end
-
+            delay(0.2)
             for i = 1, #context.scoring_hand do
                 local percent = 0.85 - (i - 0.999) / (#context.scoring_hand - 0.998) * 0.3
                 G.E_MANAGER:add_event(Event({
@@ -1973,7 +1972,7 @@ SMODS.Joker { -- Unpleasant Gradient
                     end
                 }))
             end
-
+            delay(0.5)
             return {
                 message = 'how Unpleasant',
                 colour = G.C.PURPLE,

--- a/main.lua
+++ b/main.lua
@@ -3036,7 +3036,7 @@ SMODS.Joker { -- Ledger
     key = 'ledger',
     loc_txt = {
         name = 'Ledger',
-        text = { 'Every ante, one random', 'Joker becomes {C:dark_edition}negative{}' }
+        text = { 'At the end of every ante, one', 'random Joker becomes {C:dark_edition}Negative{}' }
     },
     atlas = 'Jokers',
     pos = {

--- a/main.lua
+++ b/main.lua
@@ -688,7 +688,7 @@ SMODS.Joker { -- Microwave
         -- Thank you to theonegoodali from the Balatro Discord for helping me with this conditional
         if context.retrigger_joker_check and not context.retrigger_joker and context.other_card.ability then
             for i = 1, #food_jokers do
-                if G.localization.descriptions.Joker[context.other_card.config.center.key].name == food_jokers[i].name and food_jokers[i].name ~= 'Leftovers' then
+                if context.other_card.config.center.key == food_jokers[i].key and food_jokers[i].name ~= 'Leftovers' then
                     return {
                         message = localize('k_again_ex'),
                         repetitions = 1,
@@ -696,6 +696,7 @@ SMODS.Joker { -- Microwave
                     }
                 end
             end
+            sendDebugMessage(context.other_card.config.center.key..' is not applicable to Microwave','MaximusDebug')
         end
     end
 }
@@ -1932,7 +1933,7 @@ SMODS.Joker { -- Unpleasant Gradient
             for i = 1, #context.scoring_hand do
                 local percent = 1.15 - (i - 0.999) / (#context.scoring_hand - 0.998) * 0.3
                 G.E_MANAGER:add_event(Event({
-                    trigger = 'after',
+                    trigger = 'before',
                     delay = 0.15,
                     func = function()
                         local other_card = context.scoring_hand[i]

--- a/main.lua
+++ b/main.lua
@@ -1,6 +1,7 @@
 -- Load config and save state
 Maximus_config = SMODS.current_mod.config
 
+
 -- Joker Sprite Atlases
 SMODS.Atlas { -- Main Joker Atlas
     key = 'Jokers',
@@ -15,6 +16,7 @@ SMODS.Atlas { -- 4D Joker Atlas
     px = 71,
     py = 95
 }
+
 
 -- Set new variables to init with game
 local igo = Game.init_game_object
@@ -45,6 +47,7 @@ Game.init_game_object = function(self)
     return ret
 end
 
+
 -- Sounds
 SMODS.Sound({
     key = 'perfect',
@@ -55,6 +58,7 @@ SMODS.Sound({
     key = 'eggsplosion',
     path = 'eggsplosion.ogg'
 })
+
 
 -- Repetition Calc hook for Combo Breaker card repetition tracking
 local rep_calc = SMODS.calculate_repetitions
@@ -104,6 +108,7 @@ food_jokers = { {
     key = 'j_mxms_leftovers',
     name = 'Leftovers'
 } }
+
 
 -- Variables that change every round
 function SMODS.current_mod.reset_game_globals(run_start)
@@ -605,7 +610,7 @@ SMODS.Joker { -- Abyss
                 local flip = pseudorandom(pseudoseed('aby' .. G.GAME.round_resets.ante), 1, 2)
 
                 -- Add negative edition to random held joker
-                if flip == 1 then
+                if flip == 1 and chosen_joker ~= nil then
                     card:juice_up(0.3, 0.4)
                     chosen_joker:set_edition({
                         negative = true
@@ -696,7 +701,7 @@ SMODS.Joker { -- Microwave
                     }
                 end
             end
-            sendDebugMessage(context.other_card.config.center.key..' is not applicable to Microwave','MaximusDebug')
+            sendDebugMessage(context.other_card.config.center.key .. ' is not applicable to Microwave', 'MaximusDebug')
         end
     end
 }
@@ -1010,21 +1015,23 @@ SMODS.Joker { -- Jobber
                     pseudorandom_element(eligible_jokers, pseudoseed('jobber' .. G.GAME.round_resets.ante)) or nil
 
                 -- Copy Joker and add to hand
-                local new_card = copy_card(chosen_joker, nil, nil, nil,
-                    chosen_joker.edition and chosen_joker.edition.negative)
-                new_card:start_materialize()
-                new_card:add_to_deck()
-                if new_card.edition and new_card.edition.negative then
-                    new_card:set_edition(nil, true)
+                if chosen_joker ~= nil then
+                    local new_card = copy_card(chosen_joker, nil, nil, nil,
+                        chosen_joker.edition and chosen_joker.edition.negative)
+                    new_card:start_materialize()
+                    new_card:add_to_deck()
+                    if new_card.edition and new_card.edition.negative then
+                        new_card:set_edition(nil, true)
+                    end
+                    G.jokers:emplace(new_card)
+                    return {
+                        extra = {
+                            message = 'Jobbed',
+                            colour = G.C.YELLOW
+                        },
+                        card = card
+                    }
                 end
-                G.jokers:emplace(new_card)
-                return {
-                    extra = {
-                        message = 'Jobbed',
-                        colour = G.C.YELLOW
-                    },
-                    card = card
-                }
             end
         end
     end
@@ -3083,16 +3090,18 @@ SMODS.Joker { -- Ledger
 
                 -- Add negative edition to random held joker
 
-                chosen_joker:set_edition({
-                    negative = true
-                }, true)
-                return {
-                    extra = {
-                        message = 'Why so serious?',
-                        colour = G.C.PURPLE
-                    },
-                    card = card
-                }
+                if chosen_joker ~= nil then
+                    chosen_joker:set_edition({
+                        negative = true
+                    }, true)
+                    return {
+                        extra = {
+                            message = 'Why so serious?',
+                            colour = G.C.PURPLE
+                        },
+                        card = card
+                    }
+                end
             end
         end
     end

--- a/main.lua
+++ b/main.lua
@@ -210,7 +210,7 @@ end
 
 -- Ownership changes
 
-    -- Make Editions scale with Power Creep
+-- Make Editions scale with Power Creep
 SMODS.Edition:take_ownership('polychrome', {
     loc_vars = function(self)
         return { vars = { self.config.x_mult * G.GAME.creep_mod } }
@@ -219,7 +219,7 @@ SMODS.Edition:take_ownership('polychrome', {
         if context.post_joker or (context.main_scoring and context.cardarea == G.play) then
             return {
                 x_mult = card.edition.x_mult * G.GAME.creep_mod
-            }     
+            }
         end
     end
 })
@@ -232,7 +232,7 @@ SMODS.Edition:take_ownership('holo', {
         if context.pre_joker or (context.main_scoring and context.cardarea == G.play) then
             return {
                 mult = card.edition.mult * G.GAME.creep_mod
-            }     
+            }
         end
     end
 })
@@ -245,7 +245,7 @@ SMODS.Edition:take_ownership('foil', {
         if context.pre_joker or (context.main_scoring and context.cardarea == G.play) then
             return {
                 chips = card.edition.chips * G.GAME.creep_mod
-            }     
+            }
         end
     end
 })
@@ -1424,7 +1424,8 @@ SMODS.Joker { -- Hopscotch
     end,
     calculate = function(self, card, context)
         if context.setting_blind and G.GAME.blind:get_type() ~= 'Boss' and not context.blueprint then
-            local chance_roll = pseudorandom(pseudoseed('hopscotch' .. G.GAME.round_resets.ante), G.GAME.probabilities.normal, 3)
+            local chance_roll = pseudorandom(pseudoseed('hopscotch' .. G.GAME.round_resets.ante),
+                G.GAME.probabilities.normal, 3)
             if chance_roll == 3 then
                 -- Code derived from G.FUNCS.skip_blind
                 local _tag = G.GAME.skip_tag
@@ -1588,13 +1589,15 @@ SMODS.Joker { -- Four-Leaf Clover
         if context.before and not context.blueprint and #context.scoring_hand == 4 then
             -- Code derived from Midas Mask
             for k, v in ipairs(context.scoring_hand) do
-                v:set_ability(G.P_CENTERS.m_lucky, nil, true)
-                G.E_MANAGER:add_event(Event({
-                    func = function()
-                        v:juice_up(0.3, 0.4)
-                        return true
-                    end
-                }))
+                if not v.edition then
+                    G.E_MANAGER:add_event(Event({
+                        func = function()
+                            v:set_ability(G.P_CENTERS.m_lucky, nil, true)
+                            v:juice_up(0.3, 0.4)
+                            return true
+                        end
+                    }))
+                end
             end
 
             return {
@@ -3011,7 +3014,7 @@ SMODS.Joker { -- Chihuahua
         end
 
         if context.cardarea == G.play and context.repetition and tostring(context.other_card.base.id) == card.ability.extra.least_id and not card.ability.extra.tie then
-            local reps 
+            local reps
             if card.ability.extra.least_count <= 10 then
                 reps = card.ability.extra.least_count
             else

--- a/main.lua
+++ b/main.lua
@@ -2156,7 +2156,7 @@ SMODS.Joker { -- Coupon
     key = 'coupon',
     loc_txt = {
         name = 'Coupon',
-        text = { '{C:green}#1# in 30{} chance for shop', 'Jokers to be free' }
+        text = { '{C:green}#1# in 10{} chance for shop', 'Jokers to be free' }
     },
     atlas = 'Jokers',
     pos = {

--- a/main.lua
+++ b/main.lua
@@ -2204,21 +2204,21 @@ SMODS.Joker { -- Loony Joker
     },
     rarity = 1,
     config = {
-        t_mult = 10,
+        mult = 10,
         type = 'High Card'
     },
     blueprint_compat = true,
     cost = 3,
     loc_vars = function(self, info_queue, center)
         return {
-            vars = { center.ability.t_mult, center.ability.type }
+            vars = { center.ability.mult, center.ability.type }
         }
     end,
     calculate = function(self, card, context)
         if context.joker_main and context.scoring_name == 'High Card' then
             return {
-                mult_mod = card.ability.t_mult,
-                message = '+' .. card.ability.t_mult,
+                mult_mod = card.ability.mult,
+                message = '+' .. card.ability.mult,
                 colour = G.C.MULT,
                 card = card
             }
@@ -2239,21 +2239,21 @@ SMODS.Joker { -- Lazy Joker
     },
     rarity = 1,
     config = {
-        t_chips = 40,
+        chips = 40,
         type = 'High Card'
     },
     blueprint_compat = true,
     cost = 3,
     loc_vars = function(self, info_queue, center)
         return {
-            vars = { center.ability.t_chips, center.ability.type }
+            vars = { center.ability.chips, center.ability.type }
         }
     end,
     calculate = function(self, card, context)
         if context.joker_main and context.scoring_name == 'High Card' then
             return {
-                chip_mod = card.ability.t_chips,
-                message = '+' .. card.ability.t_chips,
+                chip_mod = card.ability.chips,
+                message = '+' .. card.ability.chips,
                 colour = G.C.CHIPS,
                 card = card
             }


### PR DESCRIPTION
- Glass Cards now scale Pessimistic Joker on break
- Holding both Faded and Smeared Jokers now guarantees a flush
- Fixed Coupon description showing incorrect odds
- Fixed Four-Leaf Clover overwriting enhancements
- Changed activation timings for Unpleasant Gradient
- Fixed Raised Fist causing crashes
- Coupon rolls can now stack (Multiple coupons give more chances at free jokers)
- Spectrals that destroy cards now scale with War
- Fixed Microwave not retriggering Jokers
- Hopscotch no longer applies tags immediately
- Fixed Lazy and Loony Jokers triggering with all hand types
- Booster Pack descriptions now change with Trick or Treat