### PR TITLE
Rewrite Food Joker definition to use a pool

### DIFF
--- a/items/jokers/breadsticks.lua
+++ b/items/jokers/breadsticks.lua
@@ -20,6 +20,9 @@ SMODS.Joker {
     },
     blueprint_compat = false,
     cost = 4,
+    pools = {
+        Food = true
+    },
     loc_vars = function(self, info_queue, card)
         local stg = card.ability.extra
         return {

--- a/items/jokers/chef.lua
+++ b/items/jokers/chef.lua
@@ -15,15 +15,8 @@ SMODS.Joker {
     calculate = function(self, card, context)
         if context.setting_blind and #G.jokers.cards + G.GAME.joker_buffer < G.jokers.config.card_limit then
             G.GAME.joker_buffer = G.GAME.joker_buffer + 1
-            local chosen_joker = nil
-            while not chosen_joker or
-                (chosen_joker.name == 'Cavendish' and not G.GAME.pool_flags.gros_michel_extinct) do
-                chosen_joker = pseudorandom_element(food_jokers, pseudoseed('chef' .. G.GAME.round_resets.ante))
-            end
             SMODS.add_card({
-                set = 'Joker',
-                key = chosen_joker.key,
-                key_append = 'chef'
+                set = 'Food',
             })
             card:juice_up(0.3, 0.4)
             G.GAME.joker_buffer = G.GAME.joker_buffer - 1

--- a/items/jokers/fortune_cookie.lua
+++ b/items/jokers/fortune_cookie.lua
@@ -16,6 +16,9 @@ SMODS.Joker {
     eternal_compat = false,
     blueprint_compat = true,
     cost = 4,
+    pools = {
+        Food = true
+    },
     config = {
         extra = {
             prob = 10,

--- a/items/jokers/four_course_meal.lua
+++ b/items/jokers/four_course_meal.lua
@@ -22,6 +22,9 @@ SMODS.Joker {
     blueprint_compat = true,
     eternal_compat = false,
     cost = 8,
+    pools = {
+        Food = true
+    },
     loc_vars = function(self, info_queue, card)
         local stg = card.ability.extra
         return { vars = { stg.chips, stg.mult, stg.Xmult, stg.money } }

--- a/items/jokers/leftovers.lua
+++ b/items/jokers/leftovers.lua
@@ -13,6 +13,9 @@ SMODS.Joker {
     blueprint_compat = false,
     eternal_compat = false,
     cost = 4,
+    pools = {
+        Food = true
+    },
     rarity = 1,
     calculate = function(self, card, context)
         if G.GAME.destroyed_food ~= '' and not context.blueprint then

--- a/items/jokers/microwave.lua
+++ b/items/jokers/microwave.lua
@@ -16,14 +16,12 @@ SMODS.Joker {
     calculate = function(self, card, context)
         -- Thank you to theonegoodali from the Balatro Discord for helping me with this conditional
         if context.retrigger_joker_check and not context.retrigger_joker and context.other_card.ability then
-            for i = 1, #food_jokers do
-                if context.other_card.config.center.key == food_jokers[i].key and food_jokers[i].name ~= 'Leftovers' then
-                    return {
-                        message = localize('k_again_ex'),
-                        repetitions = 1,
-                        card = card
-                    }
-                end
+            if mxms_is_food(context.other_card) and context.other_card.config.center.key ~= "j_mxms_leftovers" then
+                return {
+                    message = localize('k_again_ex'),
+                    repetitions = 1,
+                    card = card
+                }
             end
         end
     end

--- a/main.lua
+++ b/main.lua
@@ -196,46 +196,32 @@ SMODS.Sound({
 --#endregion
 
 --#region Misc Variables ------------------------------------------------------------------------------------
-food_jokers = { {
-    key = 'j_gros_michel',
-    name = 'Gros Michel'
-}, {
-    key = 'j_egg',
-    name = 'Egg'
-}, {
-    key = 'j_ice_cream',
-    name = 'Ice Cream'
-}, {
-    key = 'j_cavendish',
-    name = 'Cavendish'
-}, {
-    key = 'j_turtle_bean',
-    name = 'Turtle Bean'
-}, {
-    key = 'j_diet_cola',
-    name = 'Diet Cola'
-}, {
-    key = 'j_popcorn',
-    name = 'Popcorn'
-}, {
-    key = 'j_ramen',
-    name = 'Ramen'
-}, {
-    key = 'j_selzer',
-    name = 'Seltzer'
-}, {
-    key = 'j_mxms_fortune_cookie',
-    name = 'Fortune Cookie'
-}, {
-    key = 'j_mxms_leftovers',
-    name = 'Leftovers'
-}, {
-    key = 'j_mxms_breadsticks',
-    name = 'Endless Breadsticks'
-}, {
-    key = 'j_mxms_four_course_meal',
-    name = 'Four Course Meal'
-} }
+mxms_vanilla_food = {
+	j_gros_michel = true,
+	j_egg = true,
+	j_ice_cream = true,
+	j_cavendish = true,
+	j_turtle_bean = true,
+	j_diet_cola = true,
+	j_popcorn = true,
+	j_ramen = true,
+	j_selzer = true,
+}
+
+if not SMODS.ObjectTypes.Food then
+    SMODS.ObjectType {
+      key = 'Food',
+      default = 'j_egg',
+      cards = {},
+      inject = function(self)
+        SMODS.ObjectType.inject(self)
+        -- Insert base game food jokers
+        for k, _ in pairs(mxms_vanilla_food) do
+          self:inject_card(G.P_CENTERS[k])
+        end
+      end
+    }
+  end
 
 zodiac_killer_pools = {
     ['Aries'] = true,
@@ -680,6 +666,25 @@ function apply_horoscope_effects()
         G.GAME.next_ante_horoscopes["Virgo"] = false
     end
 end
+
+---Checks if a provided card is classified as a "Food Joker"
+function mxms_is_food(card)
+	local center = type(card) == "string"
+		and G.P_CENTERS[card]
+		or (card.config and card.config.center)
+  
+	if not center then
+	  return false
+	end
+  
+	-- If the center has the Food pool in its definition
+	if center.pools and center.pools.Food then
+	  return true
+	end
+  
+	-- If it doesn't, we check if this is a vanilla food joker
+	return mxms_vanilla_food[center.key]
+  end
 
 --Code from Betmma's Vouchers
 G.FUNCS.can_pick_card = function(e)


### PR DESCRIPTION
This changes the definition of the Food joker list to instead use a Food joker pool, the same way this is done in Cryptid and Paperback. The pool is created if it doesn't already exist and adds the vanilla food jokers to it, and then Maximus jokers are added to it by adding `pools = { Food = true },` to their definition. It also adds the `mxms_is_food(card)` function, which can take either a key or card object and returns true if it is a food joker.

This greatly improves cross-mod compatibility. Chef will be able to create Food jokers added by other mods that use the Food joker pool, and Microwave will be able to retrigger those same jokers. Inversely, jokers from other mods that check for Food jokers, such as Paperback's Ice Cube, will automatically recognize Maximus food jokers.