### PR TITLE
Fix Pessimistic incompatibility with glass shatters

### DIFF
--- a/lovely/pessimistic.toml
+++ b/lovely/pessimistic.toml
@@ -47,7 +47,8 @@ for k, v in ipairs(cards_destroyed) do
     if v.shattered then 
         glass_shattered[#glass_shattered+1] = v 
         if not next(SMODS.find_card('j_mxms_stone_thrower')) then
-            SMODS.calculate_context({failed_prob = true, odds = v.ability.extra - G.GAME.probabilities.normal})
+            local card_odds = (type(v.ability.extra) == "number" and v.ability.extra) or (v.ability.extra.odds and type(v.ability.extra.odds) == "number" and v.ability.extra.odds) or 1
+            SMODS.calculate_context({failed_prob = true, odds = card_odds})
         end
     end
 end


### PR DESCRIPTION
Maximus is causing crashes with modded enhancements that use the glass shattering effect, notably Ceramic cards from Paperback. This is because the `failed_prob` context is being passed with the card's `extra` table, which it expects to be a number as it is for Glass cards. This is solved by adding checking if `extra` is a number before passing it, and trying to fall back on `v.ability.extra.odds` if it isn't.