### PR TITLE
Fix crash in Sisyphus joker (missing comma)

### DIFF
--- a/items/jokers/sisyphus.lua
+++ b/items/jokers/sisyphus.lua
@@ -32,7 +32,7 @@ SMODS.Joker {
             G.E_MANAGER:add_event(Event({
                 func = function()
                     if to_big(G.GAME.chips) - to_big(G.GAME.blind.chips) < to_big(0) then
-                        SMODS.scale_card(card {
+                        SMODS.scale_card(card, {
                             ref_table = stg,
                             ref_value = "Xmult",
                             scalar_value = "gain",


### PR DESCRIPTION
I encountered a crash when triggering the Sisyphus Joker effect: attempt to call method 'init' (a nil value).

The issue was a missing comma in items/jokers/sisyphus.lua inside the SMODS.scale_card call.

Changed SMODS.scale_card(card { to SMODS.scale_card(card, {

I have tested this locally and it resolves the crash.